### PR TITLE
Update XrmExtensions.cs

### DIFF
--- a/src/XrmContext/Resources/XrmExtensions.cs
+++ b/src/XrmContext/Resources/XrmExtensions.cs
@@ -75,7 +75,7 @@ namespace DG.XrmContext
             return null;
         }
 
-        protected void SetOptionSetCollectionValue<T>(string attributeName, params T[] value)
+        protected void SetOptionSetCollectionValue<T>(string attributeName, IEnumerable<T> value)
         {
             if (value != null && value.Any())
             {


### PR DESCRIPTION
Without this change, using multi select option sets fail due to the value parameter is a enumerable of an array containing the enum values and not the actual array of enums.

The following test fails with a unable to cast dca_targetphone[] to int without the purposed change.

```
            client.Create(new dca_CallListMember
            {
                 dca_List = campaign.First().dca_telemarketinglist,
                 dca_Name = contact.FullName,
                 dca_Target = contact.ToEntityReference(),
                 dca_TargetPhone = new[] { dca_targetphone.Landline, dca_targetphone.MobilePhone, dca_targetphone.WorkPhone }
            });
```