### PR TITLE
Many to many relationship entities now include schema name

### DIFF
--- a/src/XrmContext/CodeDom/XrmCodeDom.fs
+++ b/src/XrmContext/CodeDom/XrmCodeDom.fs
@@ -318,6 +318,8 @@ let MakeEntity (entity: XrmEntity) =
   // Add static members
   cl.Members.AddRange(EntityConstructors()) |> ignore
   cl.Members.Add(Constant "EntityLogicalName" entity.logicalName) |> ignore
+  if entity.isIntersect then
+    cl.Members.Add(Constant "RelationshipSchemaName" entity.schemaName) |> ignore
   if entity.typecode.IsSome then cl.Members.Add(Constant "EntityTypeCode" entity.typecode.Value) |> ignore
   cl.Members.Add(DebuggerDisplayMember entity.primaryNameAttribute) |> ignore
 

--- a/src/XrmContext/IntermediateRepresentation.fs
+++ b/src/XrmContext/IntermediateRepresentation.fs
@@ -22,8 +22,8 @@ type XrmOptionSet = {
   isGlobal: bool
 }
 
-type XrmAttributeType = 
-  | Default of Type 
+type XrmAttributeType =
+  | Default of Type
   | OptionSet of string
   | OptionSetCollection of string
   | PartyList
@@ -66,11 +66,12 @@ type XrmEntity = {
   primaryIdAttribute: string
   stateAttribute: XrmOptionSet option
   statusAttribute: XrmOptionSet option
-  attr_vars: XrmAttribute list 
+  attr_vars: XrmAttribute list
   rel_vars: XrmRelationship list
   opt_sets: XrmOptionSet list
   alt_keys: XrmAlternateKey list
   interfaces: string list option
+  isIntersect: bool
 }
 
 type XrmIntersect = string * XrmAttribute list

--- a/src/XrmContext/Interpretation/InterpretEntityMetadata.fs
+++ b/src/XrmContext/Interpretation/InterpretEntityMetadata.fs
@@ -256,6 +256,8 @@ let interpretEntity entityNames entityMap entityToIntersects deprecatedPrefix la
 
   let desc = getDescription (getLabelOption metadata.DisplayName) metadata.Description
 
+  let isIntersect = Option.ofNullable metadata.IsIntersect ?| false
+
   // Return the entity representation
   { typecode = if includeEntityTypeCode then metadata.ObjectTypeCode.GetValueOrDefault() |> Some else None
     description = desc
@@ -270,4 +272,5 @@ let interpretEntity entityNames entityMap entityToIntersects deprecatedPrefix la
     primaryNameAttribute = metadata.PrimaryNameAttribute
     primaryIdAttribute = metadata.PrimaryIdAttribute
     interfaces = Map.tryFind metadata.LogicalName entityToIntersects
+    isIntersect = isIntersect
   }


### PR DESCRIPTION
XrmEntity now has an `isIntersect` attribute
Many to many relationship entites use this to add the `RelationshipSchemaName` string to the entity when generated