### PR TITLE
Added localization to OptionSetMetadataAttribute

### DIFF
--- a/src/XrmContext/CodeDom/XrmCodeDom.fs
+++ b/src/XrmContext/CodeDom/XrmCodeDom.fs
@@ -265,12 +265,14 @@ let MakeEntityOptionSet (optSet: XrmOptionSet) =
     let field = Field option.label option.value
     field.CustomAttributes.Add(
       CodeAttributeDeclaration(AttributeName typeof<EnumMemberAttribute>)) |> ignore
+    option.localization |> Map.iter (fun lcid localization -> 
     field.CustomAttributes.Add(
       CodeAttributeDeclaration("OptionSetMetadata",
-        [| CodeAttributeArgument(CodePrimitiveExpression(option.displayName))
+        [| CodeAttributeArgument(CodePrimitiveExpression(localization.displayName))
            CodeAttributeArgument("Index", CodePrimitiveExpression(option.index))
-           if option.description <> null then CodeAttributeArgument("Description", CodePrimitiveExpression(option.description))
-           if option.color <> null then CodeAttributeArgument("Color", CodePrimitiveExpression(option.color)) |])) |> ignore
+           CodeAttributeArgument("Lcid", CodePrimitiveExpression(lcid))
+           if localization.description <> null then CodeAttributeArgument("Description", CodePrimitiveExpression(localization.description))
+           if option.color <> null then CodeAttributeArgument("Color", CodePrimitiveExpression(option.color)) |])) |> ignore)
     enum.Members.Add(field) |> ignore)
 
   enum

--- a/src/XrmContext/CommandLine/Arguments.fs
+++ b/src/XrmContext/CommandLine/Arguments.fs
@@ -67,6 +67,10 @@ type Args private () =
       description = "Set to false to prevent generation of an Entity Type Code constant in each entity definition. Default is true."
       required=false }
 
+    { command = "localizations";
+      altCommands=["l"]
+      description="Comma seperated list of LCIDs to include as OptionSetMetadataAttribute the, default is to use UserLocalizedLabel."
+      required=false }
     ]
 
   static member connectionArgs = [

--- a/src/XrmContext/Domain.fs
+++ b/src/XrmContext/Domain.fs
@@ -35,6 +35,7 @@ type XcGenerationSettings = {
   sdkVersion: Version option
   intersections: EntityIntersect[] option
   labelMapping: (string * string)[] option
+  localizations: int[] option
   oneFile: bool
   includeEntityTypeCode: bool
 }

--- a/src/XrmContext/Generation/Setup.fs
+++ b/src/XrmContext/Generation/Setup.fs
@@ -78,7 +78,7 @@ let interpretCrmData (gSettings: XcGenerationSettings) out sdkVersion (rawState:
 
   let entityMetadata =
     publicEntities
-    |> Array.Parallel.map (interpretEntity entityNames entityMap entityToIntersects gSettings.deprecatedPrefix gSettings.labelMapping gSettings.includeEntityTypeCode sdkVersion)
+    |> Array.Parallel.map (interpretEntity entityNames entityMap entityToIntersects gSettings.deprecatedPrefix gSettings.labelMapping gSettings.localizations gSettings.includeEntityTypeCode sdkVersion)
     |> Array.sortBy (fun x -> x.schemaName)
 
 

--- a/src/XrmContext/IntermediateRepresentation.fs
+++ b/src/XrmContext/IntermediateRepresentation.fs
@@ -5,13 +5,17 @@ open System
 
 type XrmOptionSetType = Picklist | State | Status | Boolean
 
-type XrmOption = {
-  label: string
-  value: int
+type XrmOptionLocalized = {  
   displayName: string
-  index: int
   description: string
+}
+
+type XrmOption = {
+  value: int
+  label: string
+  index: int  
   color: string
+  localization: Map<int,XrmOptionLocalized>
 }
 
 type XrmOptionSet = {

--- a/src/XrmContext/Interpretation/InterpretEntityMetadata.fs
+++ b/src/XrmContext/Interpretation/InterpretEntityMetadata.fs
@@ -67,7 +67,7 @@ let interpretNormalAttribute aType (options:XrmOptionSet option) hasOptions  =
   | AttributeTypeCode.PartyList, _   -> Some PartyList
   | _ -> typeConv aType |> Default |> Some
 
-let interpretAttribute deprecatedPrefix labelmapping entityNames (e:EntityMetadata) (a:AttributeMetadata) =
+let interpretAttribute deprecatedPrefix labelmapping localizations entityNames (e:EntityMetadata) (a:AttributeMetadata) =
   let canSet = a.IsValidForCreate.GetValueOrDefault() || a.IsValidForUpdate.GetValueOrDefault()
   let canGet = a.IsValidForRead.GetValueOrDefault() || canSet
 
@@ -81,7 +81,7 @@ let interpretAttribute deprecatedPrefix labelmapping entityNames (e:EntityMetada
     let options, hasOptions =
       match a with
       | :? EnumAttributeMetadata as eam -> 
-        let options = interpretOptionSet entityNames (Some e) eam labelmapping
+        let options = interpretOptionSet entityNames (Some e) eam labelmapping localizations
         options, options.IsSome && options.Value.options.Length > 0
       | _ -> None, false
 
@@ -198,13 +198,13 @@ let interpretKeyAttribute attrTypeMap (keyMetadata:EntityKeyMetadata) =
   }
 
 
-let interpretEntity entityNames entityMap entityToIntersects deprecatedPrefix labelmapping includeEntityTypeCode sdkVersion (metadata:EntityMetadata) =
+let interpretEntity entityNames entityMap entityToIntersects deprecatedPrefix labelmapping (localizations: int[] option) includeEntityTypeCode sdkVersion (metadata:EntityMetadata) =
   if (metadata.Attributes = null) then failwith "No attributes found!"
 
   // Attributes and option sets
   let opt_sets, attr_vars = 
     metadata.Attributes 
-    |> Array.map (interpretAttribute deprecatedPrefix labelmapping entityNames metadata)
+    |> Array.map (interpretAttribute deprecatedPrefix labelmapping localizations entityNames metadata)
     |> Array.unzip
 
   let attr_vars = attr_vars |> Array.choose id |> Array.toList

--- a/src/XrmContext/Interpretation/InterpretOptionSetMetadata.fs
+++ b/src/XrmContext/Interpretation/InterpretOptionSetMetadata.fs
@@ -8,13 +8,27 @@ open Microsoft.Xrm.Sdk.Metadata
 open Utility
 open IntermediateRepresentation
 
+let getDescription (opt : OptionMetadata, lcid: int) = 
+   let desc = opt.Description.LocalizedLabels |> Seq.filter (fun f -> f.LanguageCode = lcid)
+   match desc with
+   | s when Seq.isEmpty s -> null
+   | _ -> (desc |> Seq.head).Label
+
+
+let getLocalized (opt: OptionMetadata) (labelmapping:(string*string)[] option) =  
+  opt.Label.LocalizedLabels 
+  |> Seq.map(fun f -> f.LanguageCode, {displayName = f.Label |> Utility.applyLabelMappings labelmapping; description = getDescription(opt, f.LanguageCode)}) 
+  |> Map
 
 let getLabelString (label:Label) (labelmapping:(string*string)[] option) =
+  let l = label.UserLocalizedLabel.Label 
   try
-    label.UserLocalizedLabel.Label 
-    |> Utility.applyLabelMappings labelmapping
-    |> Utility.sanitizeString 
-  with _ -> emptyLabel
+      l
+      |> Utility.applyLabelMappings labelmapping
+      |> Utility.sanitizeString 
+    with _ -> emptyLabel
+
+
   
 let getUnsanitizedLabelString (label:Label) (labelmapping:(string*string)[] option) =
   try
@@ -44,15 +58,14 @@ let getOptionsFromOptionSetMetadata (osm:OptionSetMetadata) labelMapping =
     osm.Options
     |> Seq.indexed
     |> Seq.map (fun (idx, opt) ->
-      let description =
-        match getLabelString opt.Description labelMapping with
-        | "_EmptyString" -> null
-        | s -> s
+      //let description =
+      //  match getLabelString opt.Description labelMapping with
+      //  | "_EmptyString" -> null
+      //  | s -> s
       { label = getLabelString opt.Label labelMapping
-        value = opt.Value.GetValueOrDefault()
-        displayName = getUnsanitizedLabelString opt.Label labelMapping
+        value = opt.Value.GetValueOrDefault()        
         index = idx
-        description = description
+        localization = getLocalized opt labelMapping
         color = opt.Color })
     
   options

--- a/src/XrmContext/Program.fs
+++ b/src/XrmContext/Program.fs
@@ -60,6 +60,8 @@ let getGenerationSettings parsedArgs =
 
     name, intersects)
 
+  let localizations = getListArg parsedArgs "localizations" (fun f -> Int32.Parse(f))
+
   let nsSanitizer ns =
     if String.IsNullOrWhiteSpace ns then String.Empty
     else ns.Split('.') |> Array.map sanitizeString |> String.concat "."
@@ -70,6 +72,7 @@ let getGenerationSettings parsedArgs =
     deprecatedPrefix = Map.tryFind "deprecatedPrefix" parsedArgs
     sdkVersion = getArg parsedArgs "sdkVersion" parseVersion
     intersections = intersections
+    localizations = localizations
     labelMapping = labelMapping
     oneFile = getArg parsedArgs "oneFile" parseBoolish ?| true
     includeEntityTypeCode = getArg parsedArgs "includeEntityTypeCode" parseBoolish ?| true

--- a/src/XrmContext/Resources/XrmExtensions.cs
+++ b/src/XrmContext/Resources/XrmExtensions.cs
@@ -401,21 +401,23 @@ namespace DG.XrmContext
         }
     }
 
-    [AttributeUsage(AttributeTargets.Field)]
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = true)]
     public class OptionSetMetadataAttribute : Attribute
     {
         public string Name { get; private set; }
         public int Index { get; set; }
         public string Description { get; set; }
         public string Color { get; set; }
+        public int Lcid { get; set; }
 
-        public OptionSetMetadataAttribute(string name, string description = null, string color = null) : this(name, int.MinValue, description, color) { }
-        public OptionSetMetadataAttribute(string name, int index, string description = null, string color = null)
+        public OptionSetMetadataAttribute(string name, int lcid = 1033, string description = null, string color = null) : this(name, int.MinValue,lcid, description, color) { }
+        public OptionSetMetadataAttribute(string name, int index, int lcid, string description = null, string color = null)
         {
             Name = name;
             Index = index;
             Description = description;
             Color = color;
+            Lcid = lcid;
         }
     }
 }

--- a/src/XrmContext/XrmContext.fs
+++ b/src/XrmContext/XrmContext.fs
@@ -11,7 +11,7 @@ open System.Runtime.Serialization.Json
 
 type XrmContext private () =
 
-  static member GenerateFromCrm(url, ?method, ?username, ?password, ?domain, ?ap, ?mfaAppId, ?mfaReturnUrl, ?mfaClientSecret, ?connectionString, ?out, ?entities, ?solutions, ?ns, ?context, ?deprecatedPrefix, ?sdkVersion, ?intersections,?labelMapping, ?oneFile, ?includeEntityTypeCode) = 
+  static member GenerateFromCrm(url, ?method, ?username, ?password, ?domain, ?ap, ?mfaAppId, ?mfaReturnUrl, ?mfaClientSecret, ?connectionString, ?out, ?entities, ?solutions, ?ns, ?context, ?deprecatedPrefix, ?sdkVersion, ?intersections,?labelMapping, ?oneFile, ?includeEntityTypeCode, ?localizations) = 
     let xrmAuth = 
       { XrmAuthentication.url = Uri(url)
         method = method
@@ -37,6 +37,7 @@ type XrmContext private () =
         context = context
         intersections = intersections
         labelMapping = labelMapping
+        localizations = localizations
         oneFile = oneFile ?| true
         includeEntityTypeCode = includeEntityTypeCode ?| true
        }


### PR DESCRIPTION
I extended the code generate to add multiple OptionSetMetadataAttribute to the Enum Types. One OptionSetMetadataAttribute per localization configured. This is needed if you want to show the translations in applications that uses the XrmContext (and dont want to contact CRM to get the translations). 

Unfortunately this is a breaking change for anyone that depends on a single OptionSetMetadataAttribute being present, as AllowMultiple was previously set to false. So could be that the feature should be hidden behind a commandline arg. 

![image](https://user-images.githubusercontent.com/3397744/124516695-8c3baa80-dde2-11eb-8cec-b0e3aeb7306d.png)
