### PR TITLE
Added XrmExtensions to generated namespace

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,7 @@
 # Release Notes
+### 3.0.0 - 10 June 2022
+* Added XrmExtensions to generated namespace
+
 ### 2.0.2 - 08 July 2021
 * Added support for multiple locale optionset labels (@sjkp)
 

--- a/src/XrmContext/CodeDom/XrmCodeDom.fs
+++ b/src/XrmContext/CodeDom/XrmCodeDom.fs
@@ -426,7 +426,11 @@ let CreateStandardCodeUnit ns =
   globalNs.Imports.Add(CodeNamespaceImport("System.ComponentModel.DataAnnotations"))
   globalNs.Imports.Add(CodeNamespaceImport("Microsoft.Xrm.Sdk"))
   globalNs.Imports.Add(CodeNamespaceImport("Microsoft.Xrm.Sdk.Client"))
-  globalNs.Imports.Add(CodeNamespaceImport("DG.XrmContext"))
+  
+  // Import XrmExtensions.cs
+  if String.IsNullOrWhiteSpace ns then
+    globalNs.Imports.Add(CodeNamespaceImport("DG.XrmContext"))
+  
   cu.Namespaces.Add(globalNs) |> ignore
 
   let ns = CodeNamespace(ns)

--- a/src/XrmContext/Generation/FileGeneration.fs
+++ b/src/XrmContext/Generation/FileGeneration.fs
@@ -105,8 +105,17 @@ let createMultiFileCodeDom (state: InterpretedState) =
 
   printfn "Done!"
 
+// Replace namespace in all lines
+let replaceNamespace ns (lines:string seq) =
+  if String.IsNullOrWhiteSpace ns then
+    lines
+  else 
+    lines
+    |> Seq.map (fun line -> line.Replace("DG.XrmContext", ns))
+
 // Create resource files
-let createResourceFiles out sdkVersion =
+let createResourceFiles out sdkVersion ns =
   getResourceLines "XrmExtensions.cs"
   |> removeUnsupportedLines sdkVersion
+  |> replaceNamespace ns
   |> fun lines -> File.WriteAllLines(Path.Combine(out, "XrmExtensions.cs"), lines)

--- a/src/XrmContext/Generation/GenerationMain.fs
+++ b/src/XrmContext/Generation/GenerationMain.fs
@@ -30,4 +30,4 @@ let generateFromRaw gSettings (rawState: RawState) =
   let interpretedData = interpretCrmData gSettings out sdkVersion rawState
   if gSettings.oneFile then createSingleFileCodeDom interpretedData else createMultiFileCodeDom interpretedData
 
-  createResourceFiles out sdkVersion
+  createResourceFiles out sdkVersion interpretedData.ns


### PR DESCRIPTION
Suggest bumping Major version due to breaking changes in projects that use the namespace argument and reference the namespace 'DG.XrmContext' directly.
#51