### PR TITLE
Fix for issue 57

### DIFF
--- a/src/XrmContext/CodeDom/XrmCodeDom.fs
+++ b/src/XrmContext/CodeDom/XrmCodeDom.fs
@@ -517,7 +517,11 @@ let MakeEnumsCodeUnit ns (enumCodeTypeDeclerations: CodeTypeDeclaration list) =
   let globalNs = CodeNamespace()
   globalNs.Imports.Add(CodeNamespaceImport("System.Runtime.Serialization"))
   globalNs.Imports.Add(CodeNamespaceImport("Microsoft.Xrm.Sdk.Client"))
-  globalNs.Imports.Add(CodeNamespaceImport("DG.XrmContext"))
+
+  // Import XrmExtensions.cs
+  if String.IsNullOrWhiteSpace ns then
+    globalNs.Imports.Add(CodeNamespaceImport("DG.XrmContext"))
+
   cu.Namespaces.Add(globalNs) |> ignore
 
   cu.AssemblyCustomAttributes.Add(


### PR DESCRIPTION
Made inclusion of "using DG.XrmContext;" from GlobalOptionSet file conditional. The using statement will be included when no namespace is specified just like for all the Entity specific files.
#57